### PR TITLE
Fix: 다크 모드에서 달력의 평일이 보이지 않는 현상 해결

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,7 +57,7 @@ android {
         minSdk 26
         targetSdk 33
         versionCode 1
-        versionName '1.0.1-beta01'
+        versionName '1.0.1-beta02'
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
## #20 
수정 완료! 색깔을 반환하는 확장 함수에 ``isSelected``와 ``isLight`` flag를 추가하였다.

``` Kotlin
@Composable
private fun LocalDate.color(
    isSelected: Boolean = false,
    isLight: Boolean = false,
    currentMonth: Int = this.monthValue
) = when (calculateDayType(currentMonth)) {
    DayType.Weekday -> if (isLight || isSelected) WeekdayColorOnLight else WeekDayColorOnDark
    DayType.WeekdayOverMonth -> WeekDayOverMonthColor
    DayType.Saturday -> SaturdayColor
    DayType.SaturdayOverMonth -> Color(0xFF9999FF)
    DayType.Holiday -> HolidayColor
    DayType.HolidayOverMonth -> Color(0xFFFF9999)
}
```

<img src="https://user-images.githubusercontent.com/45386920/188038354-05bfdd73-b86b-480c-bdd8-8fe17ccdea02.png" width=300>
