### PR TITLE
1.1.1 출시

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,7 +57,7 @@ android {
         minSdk 26
         targetSdk 33
         versionCode 1
-        versionName '1.1'
+        versionName '1.1.1'
         signingConfig signingConfigs.debug
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -21,8 +21,8 @@
 -renamesourcefileattribute SourceFile
 
 # Application classes that will be serialized/deserialized over Gson
--keep class com.practice.database.** { <fields>; }
--keep class com.example.domain.** { <fields>; }
+-keep class com.practice.** { <fields>; }
+-keep class com.example.** { <fields>; }
 
 # Prevent proguard from stripping interface information from TypeAdapter, TypeAdapterFactory,
 # JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)


### PR DESCRIPTION
## 버그 수정
* 일부 기기에서 매달 10일 이후의 식단이 보이지 않던 문제 해결
  * Proguard의 문제로 추정된다. 앱의 모든 클래스를 keep하도록 수정했다.