### PR TITLE
UI 리팩토링

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,7 +57,7 @@ android {
         minSdk 26
         targetSdk 33
         versionCode 1
-        versionName '1.2.1-beta01'
+        versionName '1.2.1-beta02'
         signingConfig signingConfigs.debug
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/com/practice/hanbitlunch/calendar/Calendar.kt
+++ b/app/src/main/java/com/practice/hanbitlunch/calendar/Calendar.kt
@@ -6,9 +6,6 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -46,27 +43,17 @@ fun Calendar(
     getContentDescription: (LocalDate) -> String = { "" },
     getClickLabel: (LocalDate) -> String? = { null },
 ) {
-    Column(
+    SwipeableCalendarDates(
+        getContentDescription = getContentDescription,
         modifier = modifier
             .background(MaterialTheme.colors.surface)
-    ) {
-        CalendarDays(
-            days = calendarDays(),
-            isLight = isLight,
-            modifier = Modifier.clearAndSetSemantics {}
-        )
-        SwipeableCalendarDates(
-            getContentDescription = getContentDescription,
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(MaterialTheme.colors.surface),
-            calendarState = calendarState,
-            onDateClick = onDateClick,
-            onSwiped = onSwiped,
-            isLight = isLight,
-            getClickLabel = getClickLabel,
-        )
-    }
+            .fillMaxWidth(),
+        calendarState = calendarState,
+        onDateClick = onDateClick,
+        onSwiped = onSwiped,
+        isLight = isLight,
+        getClickLabel = getClickLabel,
+    )
 }
 
 private fun calendarDays(): List<DayOfWeek> {
@@ -81,12 +68,15 @@ private fun CalendarDays(
     modifier: Modifier = Modifier,
     isLight: Boolean = true,
 ) {
-    LazyVerticalGrid(
-        columns = GridCells.Fixed(7),
-        modifier = modifier,
-    ) {
-        items(items = days, key = { it.ordinal }) {
-            CalendarDay(day = it, isLight = isLight)
+    Row(modifier = modifier) {
+        days.forEach { day ->
+            CalendarDay(
+                day = day,
+                isLight = isLight,
+                modifier = Modifier
+                    .padding(vertical = 8.dp)
+                    .weight(1f)
+            )
         }
     }
 }
@@ -128,17 +118,26 @@ fun SwipeableCalendarDates(
         modifier = modifier,
     ) { index ->
         val shownYearMonth = currentYearMonth.offset(index - firstItemIndex)
-        CalendarDates(
-            yearMonth = shownYearMonth,
-            selectedDate = calendarState.selectedDate,
-            getContentDescription = getContentDescription,
-            getClickLabel = getClickLabel,
-            onDateClick = {
-                calendarState.selectedDate = it
-                onDateClick(it)
-            },
-            isLight = isLight,
-        )
+        val calendarPage = CalendarPage.getInstance(shownYearMonth)
+        Column {
+            CalendarDays(
+                days = calendarDays(),
+                isLight = isLight,
+                modifier = Modifier
+                    .clearAndSetSemantics {}
+            )
+            CalendarContents(
+                page = calendarPage,
+                selectedDate = calendarState.selectedDate,
+                getContentDescription = getContentDescription,
+                getClickLabel = getClickLabel,
+                onDateClick = {
+                    calendarState.selectedDate = it
+                    onDateClick(it)
+                },
+                isLight = isLight,
+            )
+        }
     }
 }
 
@@ -158,6 +157,7 @@ private fun CalendarDay(
     )
 }
 
+private val Transparent = Color(0x00000000)
 private val WeekdayColorOnLight = Color(0xFF000000)
 private val WeekDayColorOnDark = Color(0xFFFFFFFF)
 private val SaturdayColor = Color(0xFF5151FF)
@@ -171,8 +171,8 @@ private fun DayOfWeek.color(isLight: Boolean = true) = when (this) {
 }
 
 @Composable
-private fun CalendarDates(
-    yearMonth: YearMonth,
+private fun CalendarContents(
+    page: CalendarPage,
     selectedDate: LocalDate,
     getContentDescription: (LocalDate) -> String,
     getClickLabel: (LocalDate) -> String?,
@@ -180,22 +180,54 @@ private fun CalendarDates(
     onDateClick: (LocalDate) -> Unit = {},
     isLight: Boolean = true,
 ) {
-    val dates = CalendarRow.getInstance(yearMonth).dates
-    LazyVerticalGrid(
-        columns = GridCells.Fixed(7),
+    Column(
         modifier = modifier,
+        verticalArrangement = Arrangement.SpaceBetween
     ) {
-        items(items = dates, key = { it.hashCode() }) { date ->
-            CalendarDate(
-                date = date,
-                onClick = { clickedDate ->
-                    onDateClick(clickedDate)
-                },
-                currentMonth = yearMonth.month,
-                isSelected = (date == selectedDate),
-                isLight = isLight,
+        page.forEachWeeks { week ->
+            CalendarWeek(
+                modifier = Modifier.weight(1f),
+                week = week,
+                selectedDate = selectedDate,
                 getContentDescription = getContentDescription,
                 getClickLabel = getClickLabel,
+                currentMonth = page.month,
+                onDateClick = onDateClick,
+                isLight = isLight
+            )
+        }
+    }
+}
+
+@Composable
+private fun CalendarWeek(
+    week: Week,
+    selectedDate: LocalDate,
+    getContentDescription: (LocalDate) -> String,
+    getClickLabel: (LocalDate) -> String?,
+    currentMonth: Int,
+    modifier: Modifier = Modifier,
+    onDateClick: (LocalDate) -> Unit = {},
+    isLight: Boolean = true,
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.Start,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        week.forEach { dayOfWeek ->
+            CalendarDate(
+                date = dayOfWeek,
+                onClick = onDateClick,
+                getContentDescription = getContentDescription,
+                getClickLabel = getClickLabel,
+                currentMonth = currentMonth,
+                isSelected = dayOfWeek == selectedDate,
+                isLight = isLight,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight()
+                    .aspectRatio(1f),
             )
         }
     }
@@ -216,13 +248,14 @@ private fun CalendarDate(
     isLight: Boolean = true,
 ) {
     val background by animateColorAsState(
-        targetValue = if (isSelected) MaterialTheme.colors.secondary else MaterialTheme.colors.surface,
+        targetValue = if (isSelected) MaterialTheme.colors.secondary else Transparent,
         animationSpec = tween(
             durationMillis = 500,
             easing = FastOutSlowInEasing,
         )
     )
     val text = if (date == LocalDate.MAX) "" else date.dayOfMonth.toString()
+
     CalendarElement(
         text = text,
         modifier = modifier
@@ -248,12 +281,7 @@ private fun CalendarElement(
     textColor: Color = Color.Unspecified,
     textStyle: TextStyle = MaterialTheme.typography.body1,
 ) {
-    Box(
-        modifier = Modifier
-            .padding(4.dp)
-            .then(modifier)
-            .aspectRatio(1f)
-    ) {
+    Box(modifier = modifier) {
         Text(
             text = text,
             modifier = Modifier.align(Alignment.Center),
@@ -332,7 +360,10 @@ private fun CalendarPreview() {
     )
     HanbitCalendarTheme(darkTheme = true) {
         Column {
-            Calendar(calendarState = calendarState)
+            Calendar(
+                calendarState = calendarState,
+                modifier = Modifier.size(width = 400.dp, height = 300.dp)
+            )
         }
     }
 }

--- a/app/src/main/java/com/practice/hanbitlunch/screen/MainScreen.kt
+++ b/app/src/main/java/com/practice/hanbitlunch/screen/MainScreen.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
-import com.practice.hanbitlunch.calendar.Calendar
+import com.practice.hanbitlunch.calendar.SwipeableCalendar
 import com.practice.hanbitlunch.calendar.rememberCalendarState
 import com.practice.hanbitlunch.components.Body
 import com.practice.hanbitlunch.components.SubTitle
@@ -40,7 +40,7 @@ fun MainScreen(
     Column(modifier = modifier.background(MaterialTheme.colors.surface)) {
         Column(modifier = Modifier.weight(1f)) {
             MainScreenHeader(year = uiState.year, month = uiState.month)
-            Calendar(
+            SwipeableCalendar(
                 calendarState = calendarState,
                 onDateClick = viewModel::onDateClick,
                 onSwiped = viewModel::onSwiped,

--- a/app/src/main/java/com/practice/hanbitlunch/screen/MainScreen.kt
+++ b/app/src/main/java/com/practice/hanbitlunch/screen/MainScreen.kt
@@ -38,7 +38,7 @@ fun MainScreen(
     val uiState = viewModel.uiState.value
     val calendarState = rememberCalendarState()
     Column(modifier = modifier.background(MaterialTheme.colors.surface)) {
-        Column {
+        Column(modifier = Modifier.weight(1f)) {
             MainScreenHeader(year = uiState.year, month = uiState.month)
             Calendar(
                 calendarState = calendarState,

--- a/app/src/test/java/com/practice/hanbitlunch/calendar/CalendarPageTest.kt
+++ b/app/src/test/java/com/practice/hanbitlunch/calendar/CalendarPageTest.kt
@@ -4,11 +4,11 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
-class CalendarRowTest {
+class CalendarPageTest {
 
     @Test
     fun test_2022_8() {
-        val row = CalendarRow.getInstance(2022, 8)
+        val row = CalendarPage.getInstance(2022, 8)
         assertThat(row.getDate(1, 1)).isEqualTo(LocalDate.of(2022, 7, 31))
         assertThat(row.getDate(1, 7)).isEqualTo(LocalDate.of(2022, 8, 6))
         assertThat(row.getDate(5, 7)).isEqualTo(LocalDate.of(2022, 9, 3))
@@ -16,7 +16,7 @@ class CalendarRowTest {
 
     @Test
     fun test_2022_2() {
-        val row = CalendarRow.getInstance(2022, 2)
+        val row = CalendarPage.getInstance(2022, 2)
         assertThat(row.getDate(1, 1)).isEqualTo(LocalDate.of(2022, 1, 30))
         assertThat(row.getDate(2, 5)).isEqualTo(LocalDate.of(2022, 2, 10))
     }


### PR DESCRIPTION
## 리팩토링 목록
* 화면 윗부분 (헤더, 달력)과 아랫부분(식단, 학사일정)의 비율을 1:1로 고정
* 달력을 ``LazyVerticalGrid``가 아닌 ``Column``과 ``Row``의 조합으로 변경
  * 달력을 week의 ``Column``으로, week는 ``Row``로 구현했다.
  * 데이터의 수가 매우 적고, 모든 데이터가 항상 화면에 보이기 때문에 Lazy composable을 쓸 필요가 없다.
* 달력 구성 요소의 이름을 의미에 맞게 변경했다.